### PR TITLE
[API-13869] - Update LighthouseCMS deploy to include environments

### DIFF
--- a/.github/workflows/send-to-lcms.yaml
+++ b/.github/workflows/send-to-lcms.yaml
@@ -75,7 +75,7 @@ jobs:
           name: changed-files
       - name: Send content to development
         env:
-          LCMS_HOST: 'dev-developer.va.gov'
+          LCMS_HOST: 'dev-api.va.gov'
           LCMS_APIKEY: ${{ secrets.LCMS_APIKEY }}
         run:
           touch output.txt;
@@ -127,7 +127,7 @@ jobs:
           name: changed-files
       - name: Send content to production
         env:
-          LCMS_HOST: 'developer.va.gov'
+          LCMS_HOST: 'api.va.gov'
           LCMS_APIKEY: ${{ secrets.LCMS_APIKEY }}
         run:
           touch output.txt;


### PR DESCRIPTION
The deploy script will now pull secrets from their associated environments (development/production). At this moment there is no production key so it's just set to `banana` so that will obviously fail. This is more to make sure that split deploys and environments are working.