### PR TITLE
use base64 to send release note

### DIFF
--- a/.github/workflows/full-seeding-of-lpb.yaml
+++ b/.github/workflows/full-seeding-of-lpb.yaml
@@ -68,7 +68,7 @@ jobs:
             echo "Posting $n to LPB";
             DATE_STRING=`echo $n | sed 's/[\/\.a-z\-]//g' | sed -E 's/([0-9]{4})([0-9]{2})([0-9]{2})/\1-\2-\3/'`;
             echo $DATE_STRING;
-            CONTENT_STRING=`cat $n | node -p 'encodeURIComponent(require("fs").readFileSync(0))'`;
+            CONTENT_STRING=`cat $n | base64`;
             TARGET_API=`echo $n | sed -E 's/.*\/([a-z\-]{1,})\/release-notes.*/\1/'`;
             echo "Target URL https://$LPB_HOST/internal/platform-backend/v0/providers/$TARGET_API/release-notes";
             echo $BEARER_TOKEN | awk {'print length'};
@@ -76,7 +76,7 @@ jobs:
               --request POST
               --header 'Content-Type:application/json'
               --header "Authorization:Bearer $BEARER_TOKEN"
-              --data "{\"date\":\"$DATE_STRING\",\"content\":\"$CONTENT_STRING\"}"
+              --data "{\"date\":\"$DATE_STRING\",\"content\":\"base64:$CONTENT_STRING\"}"
               https://$LPB_HOST/internal/platform-backend/v0/providers/$TARGET_API/release-notes;
             sleep 1;
           done;

--- a/.github/workflows/send-to-lpb.yaml
+++ b/.github/workflows/send-to-lpb.yaml
@@ -88,14 +88,14 @@ jobs:
             echo "Posting $n to LighthouseCMS";
             DATE_STRING=`echo $n | sed 's/[\/\.a-z\-]//g' | sed -E 's/([0-9]{4})([0-9]{2})([0-9]{2})/\1-\2-\3/'`;
             echo $DATE_STRING;
-            CONTENT_STRING=`cat $n | node -p 'encodeURIComponent(require("fs").readFileSync(0))'`;
+            CONTENT_STRING=`cat $n | base64`;
             TARGET_API=`echo $n | sed -E 's/.*\/([a-z\-]{1,})\/release-notes.*/\1/'`;
             echo "Target URL https://$LPB_HOST/internal/platform-backend/v0/providers/$TARGET_API/release-notes";
             curl
               --request POST
               --header 'Content-Type:application/json'
               --header "Authorization:Bearer ${{ env.bearer_token }}"
-              --data "{\"date\":\"$DATE_STRING\",\"content\":\"$CONTENT_STRING\"}"
+              --data "{\"date\":\"$DATE_STRING\",\"content\":\"base64:$CONTENT_STRING\"}"
               https://$LPB_HOST/internal/platform-backend/v0/providers/$TARGET_API/release-notes;
           done;
       - name: Comment on PR
@@ -134,13 +134,13 @@ jobs:
             echo "Posting $n to LighthouseCMS";
             DATE_STRING=`echo $n | sed 's/[\/\.a-z\-]//g' | sed -E 's/([0-9]{4})([0-9]{2})([0-9]{2})/\1-\2-\3/'`;
             echo $DATE_STRING;
-            CONTENT_STRING=`cat $n | node -p 'encodeURIComponent(require("fs").readFileSync(0))'`;
+            CONTENT_STRING=`cat $n | base64`;
             TARGET_API=`echo $n | sed -E 's/.*\/([a-z\-]{1,})\/release-notes.*/\1/'`;
             echo "Target URL https://$LPB_HOST/internal/platform-backend/v0/providers/$TARGET_API/release-notes";
             curl
               --request POST
               --header 'Content-Type:application/json'
               --header "apikey:$LPB_RSA_SECRET"
-              --data "{\"date\":\"$DATE_STRING\",\"content\":\"$CONTENT_STRING\"}"
+              --data "{\"date\":\"$DATE_STRING\",\"content\":\"base64:$CONTENT_STRING\"}"
               https://$LPB_HOST/internal/platform-backend/v0/providers/$TARGET_API/release-notes;
           done;


### PR DESCRIPTION
base64 gets around the current tic request rejections based on content in the release note

LPB change to accept base64 release note content
https://github.com/department-of-veterans-affairs/lighthouse-platform-backend/pull/181