### PR TITLE
Remove API name from the top of the release note

### DIFF
--- a/content/verification/va-letter-generator/release-notes/2022-12-14.md
+++ b/content/verification/va-letter-generator/release-notes/2022-12-14.md
@@ -1,5 +1,3 @@
-VA Letter Generator API
-
 We added the new GET letter-contents/{letterType} endpoint to the VA Letter Generator API.  
 This endpoint returns JSON-formatted text versions of letters a specified Veteran is eligible to receive.  
 The JSON-formatted letter content can be used to deliver letters in formats other than PDF.
@@ -8,8 +6,7 @@ Learn more about this API by reviewing the [VA Letter Generator documentation](h
 
 The version number for this release is 1.0.126
 
-_____________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________
-
+---
 
 We added a new API to the developer portal called the **[VA Letter Generator API](https://community.max.gov/display/VAExternal/VA+Letter+Generator+API)**.  
 This API replaces the EVSS Letter Generator Service and offers many added benefits, including:


### PR DESCRIPTION
Also changed the long line of hyphens that create an `<hr />` tag to just 3 dashes. Same output.