### PR TITLE
Release notes for appeals now accepting an ICN header

### DIFF
--- a/content/appeals/decision-reviews/release-notes/2023-01-15
+++ b/content/appeals/decision-reviews/release-notes/2023-01-15
@@ -1,3 +1,3 @@
-We added functionality to our Appeals POST endpoints that optionally permits a veteran's ICN to be provided as part of the calls headers. This is preliminary work for eventually removing SSN and using ICN in it's place.
+We added functionality to the POST endpoints that optionally permits a Veteran's ICN to be provided as part of the call headers. This is preliminary work for eventually removing SSN and using ICN instead.
 
 To learn more, read the [Decision Reviews API documentation](https://developer.va.gov/explore/appeals/docs/decision_reviews?version=current). 


### PR DESCRIPTION
We need to add a release note to document that we now accept ICN in appeals create headers.

Ticket: [Add X-VA-ICN header details to docs](https://vajira.max.gov/browse/API-22118)