### PR TITLE
API-24296: Release Note for Decision Reviews Legacy Appeals ICN Header Support

### DIFF
--- a/content/appeals/decision-reviews/release-notes/2023-02-20.md
+++ b/content/appeals/decision-reviews/release-notes/2023-02-20.md
@@ -1,4 +1,3 @@
-We added functionality to the Legacy Appeals GET endpoint that optionally permits a Veteran's ICN to be provided
-as part of the call headers. This is preliminary work for eventually removing SSN and using ICN instead.
+We added functionality to the Legacy Appeals GET endpoint that optionally permits a Veteran's ICN to be provided as part of the call headers. This is preliminary work for eventually removing SSN and using ICN instead.
 
 To learn more, read the [Decision Reviews API documentation](https://developer.va.gov/explore/appeals/docs/decision_reviews?version=current).


### PR DESCRIPTION
This release note notifies consumers of the added support for the Veteran's ICN on the Decision Reviews Legacy Appeals endpoints.

Original ticket: [API-24296](https://vajira.max.gov/browse/API-24296)