### PR TITLE
Note release of Supp Claims Alternative Signer Headers

### DIFF
--- a/content/appeals/decision-reviews/release-notes/2022-02-17.md
+++ b/content/appeals/decision-reviews/release-notes/2022-02-17.md
@@ -1,1 +1,3 @@
-We added functionality to the Supplemental Claims POST endpoints that optionally permits an Alternative Signer to be provided as part of the call headers: X-Alternate-Signer-First-Name, X-Alternate-Signer-Middle-Initial and X-Alternate-Signer-Last-Name 
+We added functionality to the Supplemental Claims POST endpoints that optionally permits an alternative signer to be provided as part of the call headers: X-Alternate-Signer-First-Name, X-Alternate-Signer-Middle-Initial, and X-Alternate-Signer-Last-Name.
+
+To learn more, read the [Decision Reviews API documentation](https://developer.va.gov/explore/appeals/docs/decision_reviews?version=current).


### PR DESCRIPTION
We accept alternative signer headers for our Supplemental Claim POST(create) endpoints and we want to let the world know !!!

https://vajira.max.gov/browse/API-15910
https://github.com/department-of-veterans-affairs/vets-api/pull/10898