### PR TITLE
API-25080: Release Note for Supplemental Claims PACT Act Boolean

### DIFF
--- a/content/appeals/decision-reviews/release-notes/2023-04-13.md
+++ b/content/appeals/decision-reviews/release-notes/2023-04-13.md
@@ -1,0 +1,5 @@
+We added functionality to the Supplemental Claims POST endpoint that optionally permits a 'potentialPactAct' boolean 
+attribute to be provided as part of the request body. When provided, this data improves internal tracking of 
+PACT-related appeal submissions.
+
+To learn more, read the [Decision Reviews API documentation](https://developer.va.gov/explore/appeals/docs/decision_reviews?version=current). 

--- a/content/appeals/decision-reviews/release-notes/2023-04-13.md
+++ b/content/appeals/decision-reviews/release-notes/2023-04-13.md
@@ -1,5 +1,5 @@
-We added functionality to the Supplemental Claims POST endpoint that optionally permits a 'potentialPactAct' boolean 
-attribute to be provided as part of the request body. When provided, this data improves internal tracking of 
+We added optional functionality to the Supplemental Claims POST endpoint that permits a 'potentialPactAct' boolean 
+attribute to be provided as part of the request body. When provided, this data improves tracking of 
 PACT-related appeal submissions.
 
 To learn more, read the [Decision Reviews API documentation](https://developer.va.gov/explore/appeals/docs/decision_reviews?version=current). 


### PR DESCRIPTION
This release note notifies consumers of the added support for a PACT Act boolean attribute on the Supplemental Claims POST endpoint.

Original ticket: [API-23078](https://vajira.max.gov/browse/API-25080)