### PR TITLE
Create 2023-05-01

### DIFF
--- a/content/health/clinical-fhir-api/release-notes/2023-05-01
+++ b/content/health/clinical-fhir-api/release-notes/2023-05-01
@@ -1,3 +1,3 @@
-We've updated the race and ethnicity URLs in R4 Patient resource records to comply with the new U.S. Core 5 standards for race and new U.S. Core 5 standards for ethnicity.
+We've updated the race and ethnicity URLs in R4 Patient resource records to comply with the new [U.S. Core 5 standards for race](http://hl7.org/fhir/us/core/STU5.0.1/StructureDefinition-us-core-race.html) and new [U.S. Core 5 standards for ethnicity](http://hl7.org/fhir/us/core/STU5.0.1/StructureDefinition-us-core-ethnicity.html).
 
 In addition, we fixed an inconsistency in the R4 MedicationRequest resource by updating it to return only the self link in an empty bundle. The first/last links will no longer be populated.

--- a/content/health/clinical-fhir-api/release-notes/2023-05-01
+++ b/content/health/clinical-fhir-api/release-notes/2023-05-01
@@ -1,0 +1,3 @@
+We've updated the race and ethnicity URLs in R4 Patient resource records to comply with the new U.S. Core 5 standards for race and new U.S. Core 5 standards for ethnicity.
+
+In addition, we fixed an inconsistency in the R4 MedicationRequest resource by updating it to return only the self link in an empty bundle. The first/last links will no longer be populated.


### PR DESCRIPTION
This release note was published under the Patient Health API 5/01/2023. It was realized that this change applies to both the Patient Health and the Clinical Health API, so this pull request is for getting the same release note that was published 5/1/23 under Patient Health to appear under the Clinical Health API release notes section of the devportal as well.