### PR TITLE
Add release notes for Decision Reviews v2 PDF downloads

### DIFF
--- a/content/appeals/decision-reviews/release-notes/2023-09-04.md
+++ b/content/appeals/decision-reviews/release-notes/2023-09-04.md
@@ -1,0 +1,12 @@
+New endpoints have been added to allow downloads of submitted PDFs. When you submit a Higher-Level Review, or a Notice of Disagreement, a Supplemental Claim, you can now access a watermarked copy of the PDF as submitted to the VA with the following caveats:
+
+1. A PDF download will become available only after the appeal has progressed to the 'submitted' state.
+2. The PDF will stop being available one week after the appeal has progressed to the 'completed' state (when the veteran's personally identifying information is purged from our severs).
+3. PDFs are only available for appeals created with an associated veteran ICN, which is provided in the `X-VA-ICN` header when the appeal is first created. If the appeal was not created with an `X-VA-ICN` header, a PDF will never become available.
+
+The PDF download endpoints are:
+* `/services/appeals/v2/decision_reviews/higher_level_reviews/ID/download`
+* `/services/appeals/v2/decision_reviews/notice_of_disagreements/ID/download`
+* `/services/appeals/v2/decision_reviews/supplemental_claims/ID/download`
+
+To learn more, find these new endpoints in the [Decision Reviews API documentation](https://developer.va.gov/explore/appeals/docs/decision_reviews?version=current). 

--- a/content/appeals/decision-reviews/release-notes/2023-09-04.md
+++ b/content/appeals/decision-reviews/release-notes/2023-09-04.md
@@ -1,8 +1,8 @@
-New endpoints have been added to allow downloads of submitted PDFs. When you submit a Higher-Level Review, or a Notice of Disagreement, a Supplemental Claim, you can now access a watermarked copy of the PDF as submitted to the VA with the following caveats:
+New endpoints have been added to allow downloads of submitted PDFs. When you submit a Higher-Level Review, a Notice of Disagreement, or a Supplemental Claim, you can now access a watermarked copy of the PDF as submitted to the VA with the following caveats:
 
 1. A PDF download will become available only after the appeal has progressed to the 'submitted' state.
-2. The PDF will stop being available one week after the appeal has progressed to the 'completed' state (when the veteran's personally identifying information is purged from our severs).
-3. PDFs are only available for appeals created with an associated veteran ICN, which is provided in the `X-VA-ICN` header when the appeal is first created. If the appeal was not created with an `X-VA-ICN` header, a PDF will never become available.
+2. The PDF will stop being available one week after the appeal has progressed to the 'completed' state. This is when the Veteran's personally identifying information is purged from our severs.
+3. PDFs are only available for appeals created with an associated Veteran ICN, which is provided in the `X-VA-ICN` header when the appeal is first created. If the appeal was not created with an `X-VA-ICN` header, a PDF will never become available.
 
 The PDF download endpoints are:
 * `/services/appeals/v2/decision_reviews/higher_level_reviews/ID/download`

--- a/content/appeals/decision-reviews/release-notes/2023-09-04.md
+++ b/content/appeals/decision-reviews/release-notes/2023-09-04.md
@@ -5,8 +5,8 @@ New endpoints have been added to allow downloads of submitted PDFs. When you sub
 3. PDFs are only available for appeals created with an associated Veteran ICN, which is provided in the `X-VA-ICN` header when the appeal is first created. If the appeal was not created with an `X-VA-ICN` header, a PDF will never become available.
 
 The PDF download endpoints are:
-* `/services/appeals/v2/decision_reviews/higher_level_reviews/ID/download`
-* `/services/appeals/v2/decision_reviews/notice_of_disagreements/ID/download`
-* `/services/appeals/v2/decision_reviews/supplemental_claims/ID/download`
+- `/services/appeals/v2/decision_reviews/higher_level_reviews/ID/download`
+- `/services/appeals/v2/decision_reviews/notice_of_disagreements/ID/download`
+- `/services/appeals/v2/decision_reviews/supplemental_claims/ID/download`
 
 To learn more, find these new endpoints in the [Decision Reviews API documentation](https://developer.va.gov/explore/appeals/docs/decision_reviews?version=current). 

--- a/content/appeals/decision-reviews/release-notes/2023-09-04.md
+++ b/content/appeals/decision-reviews/release-notes/2023-09-04.md
@@ -1,7 +1,7 @@
 New endpoints have been added to allow downloads of submitted PDFs. When you submit a Higher-Level Review, a Notice of Disagreement, or a Supplemental Claim, you can now access a watermarked copy of the PDF as submitted to the VA with the following caveats:
 
 1. A PDF download will become available only after the appeal has progressed to the 'submitted' state.
-2. The PDF will stop being available one week after the appeal has progressed to the 'completed' state. This is when the Veteran's personally identifying information is purged from our severs.
+2. The PDF will stop being available one week after the appeal has progressed to the 'completed' state. This is when the Veteran's personally identifying information is purged from our servers.
 3. PDFs are only available for appeals created with an associated Veteran ICN, which is provided in the `X-VA-ICN` header when the appeal is first created. If the appeal was not created with an `X-VA-ICN` header, a PDF will never become available.
 
 The PDF download endpoints are:


### PR DESCRIPTION
These are release notes for three new endpoints in the Decision Reviews API v2. I'll add a link to our developer docs in the dev environment here ~~once they are available (this should be within the next few days).~~ Here are the docs in dev: https://dev-developer.va.gov/explore/api/decision-reviews/docs