### PR TITLE
Create 2024-02-06.md

### DIFF
--- a/content/verification/veteran-verification/release-notes/2024-02-06.md
+++ b/content/verification/veteran-verification/release-notes/2024-02-06.md
@@ -1,1 +1,3 @@
 We updated the v2 disability rating endpoint to return only active claims and their associated disability ratings. The endpoint no longer returns all claim types. 
+
+To learn more, see the [Veteran Service History and Eligibility v2 documentation](https://developer.va.gov/explore/api/veteran-service-history-and-eligibility/docs?version=current)

--- a/content/verification/veteran-verification/release-notes/2024-02-06.md
+++ b/content/verification/veteran-verification/release-notes/2024-02-06.md
@@ -1,6 +1,1 @@
-An update was made to the disability rating endpoint to utilize a modernized service for the source data.
-
-* Only active rated disabilities are returned from /disability rating endpoint.  For example, pending claims are not included as they lack a rating value and therefore are not part of the Veteran’s current (active) disability rating profile. 
-* The request format and response returned by the API have not changed.
-* The VSHE /disability rating endpoint url that consumers use does not change.
-* Client credentials and authorizations do not change.
+We updated the v2 disability rating endpoint to return only active claims and their associated disability ratings. The endpoint no longer returns all claim types. 

--- a/content/verification/veteran-verification/release-notes/2024-02-06.md
+++ b/content/verification/veteran-verification/release-notes/2024-02-06.md
@@ -1,0 +1,6 @@
+An update was made to the disability rating endpoint to utilize a modernized service for the source data.
+
+* Only active rated disabilities are returned from /disability rating endpoint.  For example, pending claims are not included as they lack a rating value and therefore are not part of the Veteran’s current (active) disability rating profile. 
+* The request format and response returned by the API have not changed.
+* The VSHE /disability rating endpoint url that consumers use does not change.
+* Client credentials and authorizations do not change.


### PR DESCRIPTION
Created release notes for 2024-02-06 for the following:

An update was made to the disability rating endpoint to utilize a modernized service for the source data.

Only active rated disabilities are returned from /disability rating endpoint.  For example, pending claims are not included as they lack a rating value and therefore are not part of the Veteran’s current (active) disability rating profile. 
The request format and response returned by the API have not changed.
The VSHE /disability rating endpoint url that consumers use does not change.
Client credentials and authorizations do not change.