### PR TITLE
API-36509 Add security scan slack alerts

### DIFF
--- a/.github/workflows/notify-security-alerts.yaml
+++ b/.github/workflows/notify-security-alerts.yaml
@@ -1,0 +1,89 @@
+name: Notify Security Alerts
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekdays at 7 AM EST
+    - cron: 0 12 * * 1-5
+jobs:
+  check_code_scanning_alerts:
+    runs-on: ubuntu-latest
+    outputs:
+      alert_detected: ${{ steps.check.outputs.alert_detected }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ secrets.DEV_PORTAL_CONTENT_SECURITY_SCAN_WORKFLOW_TOKEN }}
+        run: |
+          gh api '/repos/department-of-veterans-affairs/developer-portal-content/code-scanning/alerts?state=open' \
+            > code-scanning.json
+          cat code-scanning.json
+          if [ "[]" != "$(cat code-scanning.json)" ]; then
+            echo "alert_detected='true'" >> $GITHUB_OUTPUT
+          fi
+
+  check_dependabot_alerts:
+    runs-on: ubuntu-latest
+    outputs:
+      alert_detected: ${{ steps.check.outputs.alert_detected }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ secrets.DEV_PORTAL_CONTENT_SECURITY_SCAN_WORKFLOW_TOKEN }}
+        run: |
+          gh api '/repos/department-of-veterans-affairs/developer-portal-content/dependabot/alerts?state=open' \
+            > dependabot.json
+          cat dependabot.json
+          if [ "[]" != "$(cat dependabot.json)" ]; then
+            echo "alert_detected='true'" >> $GITHUB_OUTPUT
+          fi
+
+  check_secret_scanning_alerts:
+    runs-on: ubuntu-latest
+    outputs:
+      alert_detected: ${{ steps.check.outputs.alert_detected }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ secrets.DEV_PORTAL_CONTENT_SECURITY_SCAN_WORKFLOW_TOKEN }}
+        run: |
+          gh api '/repos/department-of-veterans-affairs/developer-portal-content/secret-scanning/alerts?state=open' \
+            > secret-scanning.json
+          cat secret-scanning.json
+          if [ "[]" != "$(cat secret-scanning.json)" ]; then
+            echo "alert_detected='true'" >> $GITHUB_OUTPUT
+          fi
+
+  send_slack_message:
+    runs-on: ubuntu-latest
+    needs: [check_code_scanning_alerts, check_dependabot_alerts, check_secret_scanning_alerts]
+    if: needs.check_code_scanning_alerts.outputs.alert_detected || needs.check_dependabot_alerts.outputs.alert_detected || needs.check_secret_scanning_alerts.outputs.alert_detected
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    steps:
+      - id: send_slack_message
+        uses: slackapi/slack-github-action@v1.26.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          # This ID is for #team-okapi-alerts in Lighthouse Slack
+          channel-id: C05HL4MTAFR
+          payload: |
+            {
+              "text": "Developer Portal Content Security Alerts Check",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "A security vulnerability alert has been detected in the Developer Portal Content repository."
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "@teamokapi please investigate."
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
Sends a slack alert if any of the following is found in the developer-portal-content repo:
- Depandabot alerts
- Code scanning alerts
- Secret scanning alerts

This job will run on weekdays at 7 AM EST.

[This is an example of a successful run](https://github.com/department-of-veterans-affairs/developer-portal-content/actions/runs/9164634741) of this workflow, although it didn't attempt to send a slack alert because there are currently no open security alerts. This workflow is almost identical to [the one in the developer-portal repo](https://github.com/department-of-veterans-affairs/developer-portal/blob/master/.github/workflows/notify-security-alerts.yml), so I'm hoping it will be similarly successful here when there is a message to send.