### PR TITLE
Api 21577 ensure node v20. is used in github actions

### DIFF
--- a/.github/workflows/full-seeding-of-lpb.yaml
+++ b/.github/workflows/full-seeding-of-lpb.yaml
@@ -16,6 +16,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-next@v4
+        with:
+          node-version: 20
+
       - name: Find files and artifact them
         run: |
           find ./content -type f > seed-files.txt
@@ -39,6 +45,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-next@v4
+        with:
+          node-version: 20
+
       - name: NPM install
         run: npm ci
       - id: get_bearer_token
@@ -92,6 +104,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-next@v4
+        with:
+          node-version: 20
+
       - name: NPM install
         run: npm ci
       - id: get_bearer_token

--- a/.github/workflows/full-seeding-of-lpb.yaml
+++ b/.github/workflows/full-seeding-of-lpb.yaml
@@ -16,12 +16,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-next@v4
-        with:
-          node-version: 20
-
       - name: Find files and artifact them
         run: |
           find ./content -type f > seed-files.txt
@@ -45,12 +39,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-next@v4
-        with:
-          node-version: 20
-
       - name: NPM install
         run: npm ci
       - id: get_bearer_token
@@ -104,12 +92,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-next@v4
-        with:
-          node-version: 20
-
       - name: NPM install
         run: npm ci
       - id: get_bearer_token

--- a/.github/workflows/full-seeding-of-lpb.yaml
+++ b/.github/workflows/full-seeding-of-lpb.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Find files and artifact them
@@ -22,7 +22,7 @@ jobs:
           echo "All files to upload:"
           cat seed-files.txt
       - name: Save changed files list
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: seed-files
           path: seed-files.txt
@@ -36,7 +36,7 @@ jobs:
     if: ${{ inputs.environment == 'development' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: NPM install
@@ -57,7 +57,7 @@ jobs:
           echo "bearer_token=$BEARER_TOKEN" >> $GITHUB_ENV;
           echo "::set-output name=bearer_token::$BEARER_TOKEN"
       - name: Get file list
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: seed-files
       - name: Seed content to development
@@ -89,7 +89,7 @@ jobs:
     if: ${{ inputs.environment == 'production' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: NPM install
@@ -110,7 +110,7 @@ jobs:
           echo "bearer_token=$BEARER_TOKEN" >> $GITHUB_ENV;
           echo "::set-output name=bearer_token::$BEARER_TOKEN"
       - name: Get file list
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: seed-files
       - name: Seed content to production

--- a/.github/workflows/npm-checks.yml
+++ b/.github/workflows/npm-checks.yml
@@ -1,0 +1,102 @@
+name: NPM Checks
+
+on:
+  pull_request:
+    branches: [master, shutdown-master]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    outputs:
+      hash: ${{ steps.githash.outputs.hash }}
+      pr_number: ${{ steps.pr_number.outputs.pr }}
+      node_version: ${{ steps.node_version.outputs.node_version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - id: node_version
+        name: Set Node Version to ENV
+        run: |
+          NODE_VERSION=$(node -v)
+          echo $NODE_VERSION
+          echo "node_version=$NODE_VERSION" >> $GITHUB_OUTPUT
+
+      - id: pr_number
+        name: Get PR Number
+        run: |
+          PR_NUMBER=`printf $GITHUB_REF | sed 's|refs/pull/||' | sed 's|/merge||'`
+          echo $PR_NUMBER
+          echo "pr=$PR_NUMBER" >> $GITHUB_OUTPUT
+
+      - id: githash
+        name: Set git hash
+        run: |
+          GIT_HASH=$(/bin/bash -c "git log --oneline | cut -f3 -d \" \" | cut -c1-7")
+          echo $GIT_HASH
+          echo "hash=$GIT_HASH" >> $GITHUB_OUTPUT
+
+      - name: Install dependencies
+        run: npm ci
+
+  unit:
+    needs: [install]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run test
+        run: npm run test:unit:ci
+
+  security:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run test
+        run: npm audit --production --audit-level high
+
+  lint:
+    needs: [install]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run test
+        run: npm run lint
+
+  images:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run test
+        run: ./prohibit_image_files.sh origin/master HEAD

--- a/.github/workflows/npm-checks.yml
+++ b/.github/workflows/npm-checks.yml
@@ -10,60 +10,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  install:
-    runs-on: ubuntu-latest
-    outputs:
-      hash: ${{ steps.githash.outputs.hash }}
-      pr_number: ${{ steps.pr_number.outputs.pr }}
-      node_version: ${{ steps.node_version.outputs.node_version }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - id: node_version
-        name: Set Node Version to ENV
-        run: |
-          NODE_VERSION=$(node -v)
-          echo $NODE_VERSION
-          echo "node_version=$NODE_VERSION" >> $GITHUB_OUTPUT
-
-      - id: pr_number
-        name: Get PR Number
-        run: |
-          PR_NUMBER=`printf $GITHUB_REF | sed 's|refs/pull/||' | sed 's|/merge||'`
-          echo $PR_NUMBER
-          echo "pr=$PR_NUMBER" >> $GITHUB_OUTPUT
-
-      - id: githash
-        name: Set git hash
-        run: |
-          GIT_HASH=$(/bin/bash -c "git log --oneline | cut -f3 -d \" \" | cut -c1-7")
-          echo $GIT_HASH
-          echo "hash=$GIT_HASH" >> $GITHUB_OUTPUT
-
-      - name: Install dependencies
-        run: npm ci
-
-  unit:
-    needs: [install]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run test
-        run: npm run test:unit:ci
-
   security:
     runs-on: ubuntu-latest
 
@@ -76,27 +22,3 @@ jobs:
 
       - name: Run test
         run: npm audit --production --audit-level high
-
-  lint:
-    needs: [install]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run test
-        run: npm run lint
-
-  images:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run test
-        run: ./prohibit_image_files.sh origin/master HEAD

--- a/.github/workflows/send-to-lpb.yaml
+++ b/.github/workflows/send-to-lpb.yaml
@@ -65,6 +65,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-next@v4
+        with:
+          node-version: 20
+
       - name: NPM install
         run: npm ci
       - id: get_bearer_token
@@ -136,6 +142,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-next@v4
+        with:
+          node-version: 20
+          
       - name: NPM install
         run: npm ci
       - id: get_bearer_token

--- a/.github/workflows/send-to-lpb.yaml
+++ b/.github/workflows/send-to-lpb.yaml
@@ -65,12 +65,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-next@v4
-        with:
-          node-version: 20
-
       - name: NPM install
         run: npm ci
       - id: get_bearer_token
@@ -142,12 +136,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-next@v4
-        with:
-          node-version: 20
-          
       - name: NPM install
         run: npm ci
       - id: get_bearer_token

--- a/.github/workflows/send-to-lpb.yaml
+++ b/.github/workflows/send-to-lpb.yaml
@@ -26,11 +26,11 @@ jobs:
           echo $TARGET_ENVIRONMENT
           echo "target_environment=$TARGET_ENVIRONMENT" >> $GITHUB_OUTPUT
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - id: pr_files
-        uses: Ana06/get-changed-files@v2.2.0
+        uses: Ana06/get-changed-files@v2.3.0
       - id: upload_content
         name: Find files and send them
         continue-on-error: true
@@ -48,7 +48,7 @@ jobs:
           echo "Expected files changes:"
           cat changed-files.txt
       - name: Save changed files list
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: changed-files
           path: changed-files.txt
@@ -62,7 +62,7 @@ jobs:
     if: needs.gather_content.outputs.target_environment == 'development'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: NPM install
@@ -82,7 +82,7 @@ jobs:
           BEARER_TOKEN=`cat ./bearer.token`;
           echo "bearer_token=$BEARER_TOKEN" >> $GITHUB_ENV;
       - name: Get file list
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: changed-files
       - name: Send content to development
@@ -103,7 +103,7 @@ jobs:
               https://$LPB_HOST/internal/platform-backend/v0/providers/$TARGET_API/release-notes;
           done;
       - name: Comment on PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({
@@ -114,7 +114,7 @@ jobs:
             })
       - name: Previously Merged Warning Comment on PR
         if: needs.gather_content.outputs.rename_warning == 'TRUE'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({
@@ -133,7 +133,7 @@ jobs:
     if: needs.gather_content.outputs.target_environment == 'production'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: NPM install
@@ -153,7 +153,7 @@ jobs:
           BEARER_TOKEN=`cat ./bearer.token`;
           echo "bearer_token=$BEARER_TOKEN" >> $GITHUB_ENV;
       - name: Get file list
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: changed-files
       - name: Send content to production
@@ -174,7 +174,7 @@ jobs:
               https://$LPB_HOST/internal/platform-backend/v0/providers/$TARGET_API/release-notes;
           done;
       - name: Comment on PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({

--- a/content/verification/veteran-verification/release-notes/2024-06-12.md
+++ b/content/verification/veteran-verification/release-notes/2024-06-12.md
@@ -1,4 +1,4 @@
 We've updated the results returned for disability ratings.
 
-- They continue to exclude ratings that do not have a “begin” date.
+- Ratings that do not have a “begin” date continue to be excluded.
 - This does not include ratings with "Not Service Connected" and "1151 Service Denied" decisions.

--- a/content/verification/veteran-verification/release-notes/2024-06-12.md
+++ b/content/verification/veteran-verification/release-notes/2024-06-12.md
@@ -1,4 +1,4 @@
 We've updated the results returned for disability ratings.
 
-- Ratings that do not have a “begin” date continue to be excluded.
+- They continue to exclude ratings that do not have a “begin” date.
 - This does not include ratings with "Not Service Connected" and "1151 Service Denied" decisions.


### PR DESCRIPTION
Changed github action dependencies to ensure that node version 20 is being used and to improve perforamnce.

The following dependencies were updated:
```
actions/checkout@v2 .............. v4
actions/download-artifact@v1 ..... v4
actions/github-script@v6 ......... v7
actions/upload-artifact@v1 ....... v4
Ana06/get-changed-files@v2.2.0 ... v2.3.0
```
