### PR TITLE
API-44244: Add Release Note for New `final_status` Field in Benefits Intake API

### DIFF
--- a/content/benefits/benefits-intake/release-notes/2025-01-29.md
+++ b/content/benefits/benefits-intake/release-notes/2025-01-29.md
@@ -1,0 +1,7 @@
+The Final Status (`final_status`) attribute has been added to the `/uploads`, `/uploads/{id}`, and `/uploads/report` endpoints of the API. This attribute indicates whether the status of a submission is final. It will default to `false` unless one of the following conditions is met:
+- The submission reaches VBMS
+- The submission has reached the success status but will not be uploaded into VBMS
+- The submission expired
+- The submission has errored, with a DOC1XX code
+
+Submissions with a `final_status` of `true` will no longer update to a new status.

--- a/content/benefits/benefits-intake/release-notes/2025-01-29.md
+++ b/content/benefits/benefits-intake/release-notes/2025-01-29.md
@@ -1,7 +1,7 @@
 The Final Status (`final_status`) attribute has been added to the `/uploads`, `/uploads/{id}`, and `/uploads/report` endpoints of the API. This attribute indicates whether the status of a submission is final. It will default to `false` unless one of the following conditions is met:
-- The submission reaches VBMS
-- The submission has reached the success status but will not be uploaded into VBMS
-- The submission expired
-- The submission has errored, with a DOC1XX code
+- The submission reaches VBMS.
+- The submission has reached the success status but will not be uploaded into VBMS.
+- The submission expired.
+- The submission has errored, with a DOC1XX code.
 
 Submissions with a `final_status` of `true` will no longer update to a new status.

--- a/content/benefits/benefits-intake/release-notes/2025-01-29.md
+++ b/content/benefits/benefits-intake/release-notes/2025-01-29.md
@@ -2,6 +2,6 @@ The Final Status (`final_status`) attribute has been added to the `/uploads`, `/
 - The submission reaches VBMS.
 - The submission has reached the success status but will not be uploaded into VBMS.
 - The submission expired.
-- The submission has errored, with a DOC1XX code.
+- The submission has errored with a DOC1XX code.
 
 Submissions with a `final_status` of `true` will no longer update to a new status.


### PR DESCRIPTION
## Description of Change
This PR adds a release note for the new `final_status` field in the Benefits Intake API. This field has been added to the API response to provide the consumer additional information and is not a breaking change.

Content was provided by our team's PM, Michael Hobson.

## Original Issue
- [API-44244](https://jira.devops.va.gov/browse/API-44244)