### PR TITLE
Release notes for checking all pdfs pages dim in BI

### DIFF
--- a/content/benefits/benefits-intake/release-notes/2025-02-06.md
+++ b/content/benefits/benefits-intake/release-notes/2025-02-06.md
@@ -1,0 +1,12 @@
+Previously, the Benefits Intake API only checked the dimensions of the first page in a submitted PDF. This caused issues when subsequent pages exceeded size limits, leading to failed uploads with unclear error messages.
+
+With this update, the API now checks the dimensions of all pages in a submitted PDF, ensuring better validation and clearer error messaging.
+
+**Previous issues**
+- The API only checked the first page's dimensions.
+- PDFs with oversized pages beyond the first page caused failed uploads with unclear error messages.
+
+**New changes**
+- The API now checks the dimensions of **all** pages within the PDF.
+- End-users can submit PDFs with individual page dimensions up to 78" x 101".
+- If any page exceeds the limit, the API returns an error: "**Maximum page size exceeded. Limit is 78 in x 101 in**."


### PR DESCRIPTION
Release note for changes to benefits intake api. We now check all pages within a PDF for pages that exceed our page dimension restrictions.

Related Ticket:
[API-43483](https://jira.devops.va.gov/browse/API-43483)