### PR TITLE
2026-03-30.md

### DIFF
--- a/content/health/fhir-health/release-notes/2026-03-30.md
+++ b/content/health/fhir-health/release-notes/2026-03-30.md
@@ -1,0 +1,1 @@
+Data served through Patient Health API will no longer be held for 36 hours in the original data source before it is provided to applications. 

--- a/content/health/fhir-health/release-notes/2026-03-30.md
+++ b/content/health/fhir-health/release-notes/2026-03-30.md
@@ -1,1 +1,0 @@
-Data served through Patient Health API will no longer be held for 36 hours in the original data source before it is provided to applications. 

--- a/content/health/fhir-health/release-notes/PHAPI Hold Time Removal.md
+++ b/content/health/fhir-health/release-notes/PHAPI Hold Time Removal.md
@@ -1,0 +1,5 @@
+We updated the Patient Health API to remove the 36-hour hold on releasing health data to applications. Data retrieved through this API can now be released to patients as soon as it's available to VA providers. 
+
+This change brings the Patient Health API into compliance with VA’s transition to zero hold time for laboratory, radiology, and clinical note results.
+
+To learn more, visit the [Patient Health API documentation](https://developer.va.gov/explore/api/patient-health/docs?version=current).


### PR DESCRIPTION
Per 21st Century Cures Act Field Memo, beginning on January 20, 2026, VA and the Defense Health Agency (DHA) will update patient portals for diagnostics results and clinical notes to Veterans with zero hold time when the information is available to VA providers.

Why:

We need to be compliant with 21st Century Cures Act and remove hold times from PHAPI resources so that veterans can have immediate access to their data.