### PR TITLE
Create 2026-04-15.md

### DIFF
--- a/content/health/clinical-fhir-api/release-notes/2026-04-15.md
+++ b/content/health/clinical-fhir-api/release-notes/2026-04-15.md
@@ -1,0 +1,3 @@
+We've added the new endpoint POST /PractitionerRole  to version 1 of the CHAPI.
+
+This new endpoint POST /PractitionerRole must be used with the operation "$find-user-note-titles&-health-care-system=? and it returns a list of clinician note titles used to document information about visits and clinical interactions to accurately reflect visit context (e.g., telehealth, follow-up)

--- a/content/health/clinical-fhir-api/release-notes/2026-04-15.md
+++ b/content/health/clinical-fhir-api/release-notes/2026-04-15.md
@@ -1,3 +1,9 @@
-We've added the new endpoint POST /PractitionerRole  to version 1 of the CHAPI.
+We added a new endpoint to version 1 of the Clinical Health API.
 
-This new endpoint POST /PractitionerRole must be used with the operation "$find-user-note-titles&-health-care-system=? and it returns a list of clinician note titles used to document information about visits and clinical interactions to accurately reflect visit context (e.g., telehealth, follow-up)
+**What's new?**
+
+POST /PractitionerRole
+
+This endpoint returns clinician note titles using the `$find-user-note-titles&-health-care-system=?` operation. When used together, they return a list of note titles used by clinicians to log information about visits and patient interactions.
+
+This update supports more consistent documentation and helps systems reflect the full context of each patient visit (e.g., telehealth, follow-up appointments).


### PR DESCRIPTION
Problem Statement:
Current implementation forces all Clinicians using Knowtex and Abridge Scribe to record notes using a single hard-coded note title (“Primary Care”), breaking established workflows and limiting flexibility. As the AI Scribe roll-out expands to more VA sites beyond primary care, Clinicians need the ability to select from multiple note titles to accurately reflect visit context (e.g., telehealth, follow-up). Solution:
On April 15th, 2026, we'll be releasing this new endpoint to retrieve note titles and this release note contains its details.