### PR TITLE
API-47508: Remove Old Fields for MD5 Hashing Algorithm 

### DIFF
--- a/content/benefits/claims/release-notes/2026-04-08.md
+++ b/content/benefits/claims/release-notes/2026-04-08.md
@@ -1,0 +1,14 @@
+We removed the depreciated use of MD5 header hashes in place of the existing SHA256 header_hash in the following models:
+
+- `ClaimsApi::AutoEstablishedClaim`
+- `ClaimsApi::PowerOfAttorney`
+- Serialized SupportingDocuments for `ClaimsApi::EVSSClaim` and `ClaimsApi::AutoEstablishedClaim`
+
+This change applies to the following endpoints:
+
+- POST `/services/claims/v2/veterans/{veteran_icn}/claims/:claim_id`
+- POST `services/claims/v1/forms/526/:claim_id/attachments`
+- POST `/services/claims/v1/forms/2122`
+- GET `/services/claims/v2/veterans/{{veteran_icn}}/power-of-attorney/:poa_id`
+- GET `/services/claims/v1/claims/:claim_id`
+- GET `/services/claims/v2/veterans/{{veteran_icn}}/claims/:claim_id`


### PR DESCRIPTION
Added release note for [API-47508](https://jira.devops.va.gov/browse/API-47508) that removes MD5 hashes for the following models:

- `ClaimsApi::AutoEstablishedClaim`
- `ClaimsApi::PowerOfAttorney`
- Serialized SupportingDocuments for `ClaimsApi::EVSSClaim` and `ClaimsApi::AutoEstablishedClaim`

<img width="378" height="265" alt="image" src="https://github.com/user-attachments/assets/9ba023d0-5625-4162-a483-f29206ae9d68" />

