### PR TITLE
API-53882: Add logic to SupportingDocuments to filter out VA-generated documents

### DIFF
--- a/content/benefits/claims/release-notes/2026-04-09.md
+++ b/content/benefits/claims/release-notes/2026-04-09.md
@@ -1,0 +1,5 @@
+We added supporting document filtering to the V2 claims `/show` endpoint located at:
+
+- `services/claims/v2/veterans/{veteran_icn}/claims/:claim_id`
+
+The filtering changes will return only veteran/claimant generated supporting documents, and will filter out supporting documents generated from the VA that come from the Benefits Documents Claim Letters Search endpoint.


### PR DESCRIPTION
Added release note for [API-53882](https://jira.devops.va.gov/browse/API-53882) that adds supporting documents filtering to claims benefits V2 `/show` endpoint. The filtering will allow claimant/veteran generated documents and will filter out VA generated documents that come the Benefits Document Service Claim Letters Search endpoint. 

<img width="1015" height="651" alt="image" src="https://github.com/user-attachments/assets/5325c5f3-ec99-45ee-b76e-e4cbeb9982a0" />
